### PR TITLE
feat: use dumb-init

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,6 @@ COPY ./docker/entrypoint.sh ./entrypoint.sh
 
 ENV TZ=Asia/Shanghai PUID=0 PGID=0 UMASK=022 JAVA_OPTS="-Xms512m -Xmx512m"
 
-RUN apt update && apt install gosu && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install gosu dumb-init && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "/bin/bash", "/app/entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,4 +20,4 @@ chown -R ${PUID}:${PGID} /app/
 umask ${UMASK}
 
 # 启动应用
-gosu ${PUID}:${PGID} java ${JAVA_OPTS} -Dfile.encoding=utf-8 -Dspring.config.location=${CONFIG_PATH}/ org.springframework.boot.loader.JarLauncher
+exec gosu ${PUID}:${PGID} dumb-init java ${JAVA_OPTS} -Dfile.encoding=utf-8 -Dspring.config.location=${CONFIG_PATH}/ org.springframework.boot.loader.JarLauncher


### PR DESCRIPTION
Use dumb-init to keep the main program always in the first process and no zombie process appears